### PR TITLE
Fixing Cabal Versions and Stack for LiquidHaskell and Massiv dependancies

### DIFF
--- a/cl3.cabal
+++ b/cl3.cabal
@@ -183,7 +183,7 @@ benchmark bench-cl3-weigh
     cl3,
     base >=4.7 && <5,
     vector,
-    massiv,
+    massiv >= 1.0,
     weigh
   default-language: Haskell2010
 
@@ -197,5 +197,5 @@ benchmark bench-cl3-massiv-nbody
     cl3,
     base >=4.7 && <5,
     time,
-    massiv
+    massiv >= 1.0
   default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,8 +4,12 @@
 resolver: lts-18.6 # ghc-8.10.4 # Currently the only version that seems to work with LiquidHaskell
 packages:
   - .
-# allow-newer: true
+allow-newer: true
 extra-deps:
+  # For Massiv benchmarks:
+  - massiv-1.0.1.1
+  - scheduler-2.0.0
+  # For LiquidHaskell:
   - text-format-0.3.2
   - Diff-0.3.4
   - optparse-applicative-0.16.1.0


### PR DESCRIPTION
When testing the release again, it looked like I needed to add "allow-newer: true" and a massiv and scheduler versions to the stack.yaml.